### PR TITLE
[FEAT] [YGI-18] 모바일 전용 LayoutWrapper 컴포넌트 생성 및 RootLayout 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  margin: 0;
+  padding: 0;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,16 @@
 import "./globals.css";
+import LayoutWrapper from "@/components/common/LayoutWrapper";
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className="antialiased bg-white text-black">{children}</body>
+    <html lang="ko">
+      <body className="bg-white text-black antialiased flex justify-center">
+        <LayoutWrapper>{children}</LayoutWrapper>
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { SessionProvider } from "next-auth/react";
 import "./globals.css";
 import LayoutWrapper from "@/components/common/LayoutWrapper";
 
@@ -8,8 +10,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className="bg-white text-black antialiased flex justify-center">
-        <LayoutWrapper>{children}</LayoutWrapper>
+      <body className="flex justify-center antialiased">
+        <SessionProvider>
+          <LayoutWrapper>{children}</LayoutWrapper>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 export default function Home() {
   return (
-    <div>
+    <div className="bg-ku-dark-green h-screen w-full">
       <main></main>
     </div>
   );

--- a/src/components/common/LayoutWrapper.tsx
+++ b/src/components/common/LayoutWrapper.tsx
@@ -1,0 +1,11 @@
+export default function LayoutWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="w-full max-w-[420px] min-h-screen px-4 bg-white">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18

## 📝작업 내용

- 모바일 환경에 최적화된 UI 구성을 위해 `LayoutWrapper` 컴포넌트를 생성했습니다.
- `app/layout.tsx`의 RootLayout에서 해당 LayoutWrapper를 적용하여 전체 페이지에 반영했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> - LayoutWrapper의 max-width(현재 420px) 기준 논의 필요